### PR TITLE
set the secret value to uppercase by default

### DIFF
--- a/packages/ui/src/components/Join.tsx
+++ b/packages/ui/src/components/Join.tsx
@@ -88,7 +88,7 @@ export const Join = () => {
           onChange={(e) =>
             !e.currentTarget.validity.patternMismatch &&
             !e.currentTarget.validity.tooLong &&
-            setSecret(e.currentTarget.value)
+            setSecret(e.currentTarget.value.toUpperCase())
           }
         />
       </section>


### PR DESCRIPTION
When one enters the secret, the input appears to be uppercased but fails when the user uses lowercase (without caps lock). This causes an error when trying to create a connection.

This PR sets the secret value to be uppercased by default even if the user doesn't set it on their keyboard.